### PR TITLE
fix api usage: use v1beta1 instead v1

### DIFF
--- a/src/main/java/io/fabric8/ManualCronJobTrigger.java
+++ b/src/main/java/io/fabric8/ManualCronJobTrigger.java
@@ -1,8 +1,8 @@
 package io.fabric8;
 
-import io.fabric8.kubernetes.api.model.batch.v1.CronJob;
 import io.fabric8.kubernetes.api.model.batch.v1.Job;
 import io.fabric8.kubernetes.api.model.batch.v1.JobBuilder;
+import io.fabric8.kubernetes.api.model.batch.v1beta1.CronJob;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
 
@@ -14,7 +14,7 @@ public class ManualCronJobTrigger {
     }
 
     private static Job createManualJob(KubernetesClient kubernetesClient, String namespace, String cronJobName, String jobName) {
-        CronJob cronJob = kubernetesClient.batch().v1().cronjobs().inNamespace(namespace).withName(cronJobName).get();
+        CronJob cronJob = kubernetesClient.batch().v1beta1().cronjobs().inNamespace(namespace).withName(cronJobName).get();
 
         Job newJobToCreate = new JobBuilder()
                 .withNewMetadata()


### PR DESCRIPTION
**Why**
This is for version `5.12`, `CronJobs` are not part of `v1`. Using `v1beta1` have it.

**Goal**
Having an example for version `5.12` which is able to manually trigger existing cronjobs. 